### PR TITLE
Add basic priority Comparator

### DIFF
--- a/src/main/scala/Comparator.scala
+++ b/src/main/scala/Comparator.scala
@@ -1,0 +1,25 @@
+package compaction_unit
+
+import chisel3._
+import chisel3.util._
+
+
+/** A class for priority Comparator. 
+ * The module takes a list of numbers and returns index of the smallest number. 
+ * If two numbers are equal, the one with lower index gets returned.
+ *
+ *  @param busWidth, the number of bits that each number has.
+ *  @param n, how many numbers will be compared.
+ */
+class Comparator(busWidth: Int = 4, n: Int = 4) extends Module {
+    val io = IO(new Bundle {
+        val in = Input(Vec(n, UInt(busWidth.W)))
+        val out = Output(UInt(log2Ceil(n).W))
+    })
+
+    val indexesArray = VecInit(Seq.tabulate(n)(i => i.U(log2Ceil(n).W)))
+
+    io.out := indexesArray.reduce { (indexA, indexB) =>
+        Mux(io.in(indexA) <= io.in(indexB), indexA, indexB)
+    }
+}

--- a/src/test/scala/ComparatorSpec.scala
+++ b/src/test/scala/ComparatorSpec.scala
@@ -1,0 +1,31 @@
+package compaction_unit
+
+import chisel3._
+import chiseltest._
+import org.scalatest.freespec.AnyFreeSpec
+import chisel3.experimental.BundleLiterals._
+
+
+class ComparatorSpec extends AnyFreeSpec with ChiselScalatestTester {
+    "Should return a correct index" in {
+        test(new Comparator(4, 4)) { dut =>
+            val testCases = Seq(
+                (1, 2, 3, 4, 0), // Smallest value at index 0
+                (3, 2, 4, 5, 1), // Smallest value at index 1
+                (5, 4, 3, 6, 2), // Smallest value at index 2
+                (9, 8, 7, 6, 3), // Smallest value at index 3
+                (7, 7, 7, 7, 0), // Smallest value at index 0 (prioritize lower index in case of equal values)
+                (8, 7, 7, 9, 1)  // Smallest value at index 1
+            )
+
+            for ((in0, in1, in2, in3, expected) <- testCases) {
+                dut.io.in(0).poke(in0.U)
+                dut.io.in(1).poke(in1.U)
+                dut.io.in(2).poke(in2.U)
+                dut.io.in(3).poke(in3.U)
+                dut.clock.step()
+                dut.io.out.expect(expected.U)
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a basic priority Compactor. It will probably require some changes here and there in the future but basis of priority comparing numbers is done.

closes #7