### PR TITLE
KvTransfer uses mask to load selected buffers, Merger accepts a default mask on reset

### DIFF
--- a/src/main/scala/NextIndexSelector.scala
+++ b/src/main/scala/NextIndexSelector.scala
@@ -1,0 +1,40 @@
+package compaction_unit
+
+import chisel3._
+import chisel3.util._
+
+
+/** A class for combinational NextIndexSelector
+ * This module is used to select next index based on current index and mask.
+ * More examples of how this module works can be found in the tests.
+ *
+ *  @param n, number of indexes.
+ */
+class NextIndexSelector(n: Int) extends Module {
+    val io = IO(new Bundle {
+        val mask = Input(UInt(n.W))
+        val currentIndex = Input(UInt(log2Ceil(n).W))
+
+        val nextIndex = Output(UInt(log2Ceil(n).W))
+        val overflow = Output(Bool())
+    })
+
+    // Disable all indexes that are less than currentIndex
+    val modifiedMask = Wire(Vec(n, Bool()))
+    for (i <- 0 until n) {
+        when (i.U <= io.currentIndex) {
+            modifiedMask(i) := false.B
+        }.otherwise {
+            modifiedMask(i) := io.mask(i)
+        }
+    }
+
+    // We do not have any indexes on the left side of currentIndex, use original mask
+    when (Cat(modifiedMask).asUInt === 0.U) {
+        io.nextIndex := PriorityEncoder(io.mask)
+        io.overflow := true.B
+    }.otherwise {
+        io.nextIndex := PriorityEncoder(modifiedMask.asUInt)
+        io.overflow := false.B
+    }
+}

--- a/src/test/scala/KvRingBuffersAndKvTransferAndKeyBufferSpec.scala
+++ b/src/test/scala/KvRingBuffersAndKvTransferAndKeyBufferSpec.scala
@@ -28,6 +28,7 @@ class TestKvTransferIO(busWidth: Int, numberOfBuffers: Int) extends Bundle {
     val command = Input(UInt(2.W))
     val stop = Input(Bool())
     val busy = Output(Bool())
+    val mask = Input(UInt(numberOfBuffers.W))
 }
 
 class TestKeyBufferIO(busWidth: Int, numberOfBuffers: Int) extends Bundle {
@@ -40,6 +41,7 @@ class TestKeyBufferIO(busWidth: Int, numberOfBuffers: Int) extends Bundle {
 
 class TestMergerIO(busWidth: Int, numberOfBuffers: Int) extends Bundle {
     val reset = Input(Bool())
+    val mask = Input(UInt(numberOfBuffers.W))
 
     val isResultValid = Output(Bool())
     val haveWinner = Output(Bool())
@@ -96,6 +98,7 @@ class TopTestModule(busWidth: Int, numberOfBuffers: Int) extends Module {
     topKvTransfer.io.stop <> io.kvTransfer.stop
     topKvTransfer.io.command <> io.kvTransfer.command
     topKvTransfer.io.busy <> io.kvTransfer.busy
+    topKvTransfer.io.mask <> io.kvTransfer.mask
     topKvTransfer.io.deqKvPair <> DontCare
 
     // connect TopKvTransfer to KeyBuffer
@@ -154,6 +157,7 @@ class TopTestMergerModule(busWidth: Int, numberOfBuffers: Int) extends Module {
     topKvTransfer.io.stop <> io.kvTransfer.stop
     topKvTransfer.io.command <> io.kvTransfer.command
     topKvTransfer.io.busy <> io.kvTransfer.busy
+    topKvTransfer.io.mask <> io.kvTransfer.mask
 
     // connect TopKvTransfer to KeyBuffer
     keyBuffer.io.enq <> topKvTransfer.io.deq
@@ -173,6 +177,7 @@ class TopTestMergerModule(busWidth: Int, numberOfBuffers: Int) extends Module {
     io.merger.winnerIndex <> merger.io.winnerIndex
     io.merger.nextKvPairsToLoad <> merger.io.nextKvPairsToLoad
     io.merger.reset <> merger.io.reset
+    io.merger.mask <> merger.io.mask
 
     // Connect output of KvTransfer to input of KVOutputBuffer
     kvOutputBuffer.io.enq <> topKvTransfer.io.deqKvPair
@@ -257,6 +262,7 @@ class KvRingBuffersAndKvTransferAndKeyBufferSpec extends AnyFreeSpec with Chisel
 
             // Send command to KvTransfer to start filling KeyBuffer with chunks
             dut.io.kvTransfer.command.poke("b01".U)
+            dut.io.kvTransfer.mask.poke("b1111".U)
             dut.clock.step()
             dut.io.kvTransfer.command.poke("b00".U)
 
@@ -348,6 +354,7 @@ class KvRingBuffersAndKvTransferAndKeyBufferSpec extends AnyFreeSpec with Chisel
                 dut.io.buffers(i).isInputKey.poke(false.B)
             }
             dut.io.merger.reset.poke(true.B)
+            dut.io.merger.mask.poke("b1111".U)
             dut.clock.step()
             dut.io.merger.reset.poke(false.B)
 
@@ -428,6 +435,7 @@ class KvRingBuffersAndKvTransferAndKeyBufferSpec extends AnyFreeSpec with Chisel
 
             // Send command to KvTransfer to start filling KeyBuffer with chunks
             dut.io.kvTransfer.command.poke("b01".U)
+            dut.io.kvTransfer.mask.poke("b1111".U)
             dut.clock.step()
             dut.io.kvTransfer.command.poke("b00".U)
 

--- a/src/test/scala/MergerSpec.scala
+++ b/src/test/scala/MergerSpec.scala
@@ -14,6 +14,7 @@ class MergerSpec extends AnyFreeSpec with ChiselScalatestTester {
         test(new Merger(busWidth = 4, numberOfBuffers = 4)).withAnnotations(Seq(WriteVcdAnnotation)) { dut =>
             // reset Merger for a new comparison round
             dut.io.reset.poke(true.B)
+            dut.io.mask.poke("b1111".U)
             dut.clock.step()
             dut.io.reset.poke(false.B)
 
@@ -113,6 +114,7 @@ class MergerSpec extends AnyFreeSpec with ChiselScalatestTester {
         test(new Merger(busWidth = 4, numberOfBuffers = 4)).withAnnotations(Seq(WriteVcdAnnotation)) { dut =>
             // reset Merger for a new comparison round
             dut.io.reset.poke(true.B)
+            dut.io.mask.poke("b1111".U)
             dut.clock.step()
             dut.io.reset.poke(false.B)
             
@@ -202,6 +204,7 @@ class MergerSpec extends AnyFreeSpec with ChiselScalatestTester {
         test(new Merger(busWidth = 4, numberOfBuffers = 4)).withAnnotations(Seq(WriteVcdAnnotation)) { dut =>
             // reset Merger for a new comparison round
             dut.io.reset.poke(true.B)
+            dut.io.mask.poke("b1111".U)
             dut.clock.step()
             dut.io.reset.poke(false.B)
             

--- a/src/test/scala/NextIndexSelectorSpec.scala
+++ b/src/test/scala/NextIndexSelectorSpec.scala
@@ -1,0 +1,40 @@
+package compaction_unit
+
+import chisel3._
+import chiseltest._
+import org.scalatest.freespec.AnyFreeSpec
+import chisel3.experimental.BundleLiterals._
+
+
+class NextIndexSelectorSpec extends AnyFreeSpec with ChiselScalatestTester {
+    "Different inputs produce correct outputs" in {
+        test(new NextIndexSelector(n = 4)).withAnnotations(Seq(WriteVcdAnnotation)) { dut =>
+            val testCases = Seq(
+                // mask, currentIndex, nextIndex, overflow
+                ("b1111", 0, 1, false),
+                ("b1111", 1, 2, false),
+                ("b1111", 2, 3, false),
+                ("b1111", 3, 0, true),
+
+                ("b1001", 0, 3, false),
+                ("b0100", 2, 2, true),
+                ("b1000", 3, 3, true),
+                ("b0110", 2, 1, true),
+                ("b0110", 1, 2, false),
+                
+                // If mask is there, the last index is always selected
+                ("b0000", 0, 3, true),
+                ("b0000", 1, 3, true),
+                ("b0000", 2, 3, true),
+                ("b0000", 3, 3, true),
+            )
+
+            for ((mask, currentIndex, nextIndex, overflow) <- testCases) {
+                dut.io.mask.poke(mask.U)
+                dut.io.currentIndex.poke(currentIndex.U)
+                dut.io.nextIndex.expect(nextIndex.U)
+                dut.io.overflow.expect(overflow.B)
+            }
+        }
+    }
+}


### PR DESCRIPTION
The mask usage by both KvTransfer and Merger shifts the responsibility of knowing which buffers are excluded to the Controller. The Controller should know and handle empty buffers, whatever data was received, etc. KvTransfer and Merger should have limited knowledge of what is going on outside.

- Adds NextIndexSelector module that selects next index based on mask value;
- Modifies KvTransfer to use NextIndexSelector;
- Allows default mask to be modified for Merger when io.reset is set.